### PR TITLE
Updates "editors", removes "authors", adds Sibyl

### DIFF
--- a/audit-appendix.html
+++ b/audit-appendix.html
@@ -11,7 +11,12 @@
     specStatus: "unofficial",
     editors: [{
       name: "Mike Ritter",
-      company: "Chronopolis"
+      company: "Chronopolis",
+      companyURL: "http://libraries.ucsd.edu/chronopolis/"
+    },{
+      name: "Sibyl Schaefer",
+      company: "University of California, San Diego",
+      companyURL: "https://ucsd.edu"
     }],
     gitHub: "ucsdlib/otm-specs",
     shortName: "audit-appendix",
@@ -164,7 +169,7 @@
     <section>
       <h3>Deletion</h3>
       A Deletion event represents the removal of one or more files from DDP storage.
-       
+
 
       <table id="delete-fields" class="simple">
         <thead>
@@ -196,7 +201,7 @@
 
     <section>
       <h3>Repair</h3>
-      A Repair event occurs when a DDP resolves any file corruption. Although this is internal to 
+      A Repair event occurs when a DDP resolves any file corruption. Although this is internal to
       the DDP, it is considered to be an event that may be auditable.
 
       <table id="repair-fields" class="simple">

--- a/otm-bridge.html
+++ b/otm-bridge.html
@@ -12,7 +12,11 @@
         editors: [{
           name: "Bill Branan",
           company: "LYRASIS",
-          companyURL: "https://lyrasis.org",
+          companyURL: "https://lyrasis.org"
+        },{
+          name: "Sibyl Schaefer",
+          company: "University of California, San Diego",
+          companyURL: "https://ucsd.edu"
         }],
         gitHub: "ucsdlib/otm-specs",
         shortName: "otm-bridge-api",

--- a/otm-gateway.html
+++ b/otm-gateway.html
@@ -10,14 +10,13 @@
       var respecConfig = {
         specStatus: "unofficial",
         editors: [{
-          name: "tom johnson",
+          name: "Tom Johnson",
           company: "University of California, Santa Barbara Library",
-          companyURL: "https://www.library.ucsb.edu/",
-        }],
-        authors: [{
-          name: "Bill Branan",
-          company: "LYRASIS",
-          companyURL: "https://lyrasis.org",
+          companyURL: "https://www.library.ucsb.edu/"
+        },{
+          name: "Sibyl Schaefer",
+          company: "University of California, San Diego",
+          companyURL: "https://ucsd.edu"
         }],
         gitHub: "ucsdlib/otm-specs",
         shortName: "otm-gateway-api",

--- a/preservation-workflow.html
+++ b/preservation-workflow.html
@@ -11,7 +11,12 @@
     specStatus: "unofficial",
     editors: [{
       name: "Mike Ritter",
-      company: "Chronopolis"
+      company: "Chronopolis",
+      companyURL: "http://libraries.ucsd.edu/chronopolis/"
+    },{
+      name: "Sibyl Schaefer",
+      company: "University of California, San Diego",
+      companyURL: "https://ucsd.edu"
     }],
     gitHub: "ucsdlib/otm-specs",
     shortName: "preservation-workflow-appendix",
@@ -33,10 +38,10 @@
   <section id='abstract'>
     <p>
       The preservation workflow outlines the expected behavior from a DDP and how it will interact with
-      the OTM Bridge. It then does a brief dive into what the Chronopolis workflow will look like.     
+      the OTM Bridge. It then does a brief dive into what the Chronopolis workflow will look like.
     </p>
     <p>
-      This workflow uses an intermideriary service which transforms data from the OTM Bridge to something 
+      This workflow uses an intermideriary service which transforms data from the OTM Bridge to something
       usable by the DDP and handles queries for OTM actions to perform. The implmentation of this
       piece will be dependent on the architecture of the DDP, and is only as a separate service in order to
       delineate the operations which are likely required by a DDP.


### PR DESCRIPTION
Makes consistent use of the "editors" field. Removes use of the "authors" field. The listed Editors for each document are the person primarily responsible for writing the specific document (https://wiki.duraspace.org/display/OTM/Team+Roles+and+Responsibilities) and Sibyl.

Based on https://github.com/w3c/respec/wiki/ReSpec-Editor's-Guide:

> Editors are the people in charge of the document. Authors are people who produced substantial contributions, but did not manage the document per se. *Most of the time authors are not specified,* but that practice varies between groups (it was more common in XGs for instance, or sometimes in order to get academic credit the whole group is mentioned). Here is an example of specifying two editors and one author (with the surrounding document clipped for readability):

Also adds a link for Chronopolis (for Mike)