### PR TITLE
Fixes typos in specs

### DIFF
--- a/audit-appendix.html
+++ b/audit-appendix.html
@@ -42,7 +42,7 @@
 
   <section>
     <h2>Status of This Document</h2>
-    <p>This document is an appendix to a specification, created as part of the One-to-Many grant, funded by the Andrew W.
+    <p>This document is an appendix to a specification, created as part of the One to Many grant, funded by the Andrew W.
     Mellon Foundation.</p>
   </section>
 
@@ -55,8 +55,8 @@
     </p>
     <section>
       <h3>Ingest</h3>
-      <p>The Ingest event represents the Ingestion of content from an OTM Gateway by a DDP. This event can represent either a
-      filegroup being Ingested or a file being ingested.<p>
+      <p>The Ingest event represents the ingestion of content from an OTM Gateway by a DDP. This event can represent either a
+      filegroup being ingested or a file being ingested.<p>
 
       <table id="ingest-fields" class="simple">
         <thead>

--- a/otm-bridge.html
+++ b/otm-bridge.html
@@ -46,7 +46,7 @@
 
     <section>
       <h2>Status of This Document</h2>
-      <p>This document is a draft of a specification, created as part of the One-to-Many grant, funded by the Andrew W.
+      <p>This document is a draft of a specification, created as part of the One to Many grant, funded by the Andrew W.
       Mellon Foundation.</p>
     </section>
 
@@ -190,7 +190,7 @@
           <li>Request Body: <code>JSON</code>
             <ul>
               <li>Filegroup ID: Identifies a filegroup. Filegroups are generic groupings of files that can be used to
-              capture structure such as in a digital object or work</li>
+              capture structure such as in a digital object or work.</li>
               <li><code>version</code>: The version of a filegroup</li>
               <li><code>files</code>: List of files included in the filegroup</li>
               <li>File ID: Identifies a file within a filegroup</li>
@@ -624,7 +624,7 @@
               <li>File ID: Identifies a file to be deleted</li>
               <li>File Checksum: The checksum of a file of the file to be deleted. The checksum type must match the type
               returned in <a>Get Deposited Details</a>. Including the checksum is optional and is used only to verify that
-              the correct file is being deleted</li>
+              the correct file is being deleted.</li>
             </ul>
           </li>
           <pre class="example">
@@ -758,7 +758,7 @@
           <li>Request Path: <code>/audit</code></li>
           <li>Response Body: <code>JSON</code>
             <ul>
-              <li>ID: Identifier of Filegroup or File to which this audit event it to be applied</li>
+              <li>ID: Identifier of Filegroup or File to which this audit event is to be applied</li>
               <li><code>event-type</code>: Type of event</li>
               <li><code>event</code>: Event details</li>
             </ul>
@@ -793,7 +793,7 @@
             <ul>
               <li><code>filegroup-id</code>: The identifier of the filegroup for which an audit report is requested</li>
               <li><code>file-id</code>: (Optional) The identifier of the file for which an audit report is requested. If this
-              is not provided the audit report is requested based on the filegroup-id</li>
+              is not provided the audit report is requested based on the filegroup-id.</li>
             </ul>
           </li>
           <li>Response Body: <code>JSON</code>

--- a/otm-gateway.html
+++ b/otm-gateway.html
@@ -45,7 +45,7 @@
 
     <section>
       <h2>Status of This Document</h2>
-      <p>This document is a draft of a specification, created as part of the One-to-Many grant, funded by the Andrew W.
+      <p>This document is a draft of a specification, created as part of the One to Many grant, funded by the Andrew W.
       Mellon Foundation.</p>
     </section>
 

--- a/preservation-workflow.html
+++ b/preservation-workflow.html
@@ -68,7 +68,7 @@
 
   <section>
     <h2>Status of This Document</h2>
-    <p>This document is an appendix to a specification, created as part of the One-to-Many grant, funded by the Andrew W.
+    <p>This document is an appendix to a specification, created as part of the One to Many grant, funded by the Andrew W.
     Mellon Foundation.</p>
   </section>
 
@@ -161,7 +161,7 @@
 
     <section>
       <h3>DDP Workflow</h3>
-      <p>The DDP portion of the Deposit workflow assumes that the OTM Bridge has already performed initial processing in order 
+      <p>The DDP portion of the Deposit workflow assumes that the OTM Bridge has already performed initial processing in order
       to prepare the filegroup for ingestion into a DDP.</p>
 
       <h4>Chronopolis Implementation Notes</h4>
@@ -199,7 +199,7 @@
           Query Chronopoils Ingest API for Deposit status
           <ul>
             <li>
-              Inform the OTM Bridge using <a href="otm-bridge.html#complete-deposit">POST /deposit/{filegroup-id}</a> when 
+              Inform the OTM Bridge using <a href="otm-bridge.html#complete-deposit">POST /deposit/{filegroup-id}</a> when
               the Deposit has fully distrubted throughout Chronopolis
             </li>
             <li>Create an <a href="audit-appendix.html#ingest">Ingest</a> audit event for the deposit</li>
@@ -249,7 +249,7 @@
           Query Chronopoils Ingest API for Deposit status
           <ul>
             <li>
-              Inform the OTM Bridge using <a href="otm-bridge.html#complete-deposit">POST /deposit/{filegroup-id}</a> when the 
+              Inform the OTM Bridge using <a href="otm-bridge.html#complete-deposit">POST /deposit/{filegroup-id}</a> when the
               Deposit has fully distrubted throughout Chronopolis
             </li>
             <li>Create an <a href="audit-appendix.html#ingest">Ingest</a> audit event for the deposit</li>


### PR DESCRIPTION
Resolves edits in audit appendix, and bridge spec from https://github.com/ucsdlib/otm-specs/issues/25. Does not resolve edits in preservation workflow.