### PR TITLE
Moves copyright statement

### DIFF
--- a/audit-appendix.html
+++ b/audit-appendix.html
@@ -23,13 +23,15 @@
     wg: "One to Many Working Group",
     wgURI: "https://wiki.duraspace.org/display/OTM",
     edDraftURI: "https://github.com/ucsdlib/otm-specs/blob/master/audit-appendix.html",
-    overrideCopyright: "<p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.</p>",
     maxTocLevel: 3
   };
   </script>
   <link rel="stylesheet" href="otm-styles.css">
 </head>
 <body>
+  <p class='copyright'>This document is licensed under a
+    <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.
+  </p>
   <section id='abstract'>
     <p>
       This document defines a set of events that can be used and extended to communicate status about content that has been

--- a/otm-bridge.html
+++ b/otm-bridge.html
@@ -23,13 +23,15 @@
         wg: "One to Many Working Group",
         wgURI: "https://wiki.duraspace.org/display/OTM",
         edDraftURI: "https://github.com/ucsdlib/otm-specs/blob/master/otm-bridge.html",
-        overrideCopyright: "<p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.</p>",
         maxTocLevel: 3
       };
     </script>
     <link rel="stylesheet" href="otm-styles.css">
   </head>
   <body>
+    <p class='copyright'>This document is licensed under a
+      <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.
+    </p>
     <section id='abstract'>
       <p>
         The One To Many (OTM) Bridge API Specification is one of two APIs used to support communication between digital

--- a/otm-gateway.html
+++ b/otm-gateway.html
@@ -23,13 +23,15 @@
         wg: "One to Many Working Group",
         wgURI: "https://wiki.duraspace.org/display/OTM",
         edDraftURI: "https://github.com/ucsdlib/otm-specs/blob/master/otm-gateway.html",
-        overrideCopyright: "<p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.</p>",
         maxTocLevel: 3
       };
     </script>
     <link rel="stylesheet" href="otm-styles.css">
   </head>
   <body>
+    <p class='copyright'>This document is licensed under a
+      <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.
+    </p>
     <section id='abstract'>
       <p>
         The One To Many (OTM) Gateway API Specification is one of two APIs used to support communication between digital

--- a/preservation-workflow.html
+++ b/preservation-workflow.html
@@ -23,7 +23,6 @@
     wg: "One to Many Working Group",
     wgURI: "https://wiki.duraspace.org/display/OTM",
     edDraftURI: "https://github.com/ucsdlib/otm-specs/blob/master/audit-appendix.html",
-    overrideCopyright: "<p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.</p>",
     maxTocLevel: 3,
     localBiblio: {
       "APTrust-Volume-Service": {
@@ -40,6 +39,9 @@
   <link rel="stylesheet" href="otm-styles.css">
 </head>
 <body>
+  <p class='copyright'>This document is licensed under a
+    <a class='subfoot' href='https://creativecommons.org/licenses/by/4.0/' rel='license'>Creative Commons Attribution 4.0 License</a>.
+  </p>
   <section id='abstract'>
     <p>
       The One To Many (OTM) Specification defines two APIs to support communication between digital content


### PR DESCRIPTION
Resolves warning: "The overrideCopyright configuration option is deprecated. Please use `<p class="copyright">` instead."