### PR TITLE
Change workflow "deposit" to "submit"

### DIFF
--- a/hyrax-workflow.html
+++ b/hyrax-workflow.html
@@ -86,10 +86,10 @@
       <h3>States</h3>
       <dl>
         <dt>New</dt>
-        <dd>The state of objects that are not yet deposited. Objects are in this state before being created and assigned an identifier.</dd>
+        <dd>The state of objects that are not yet submitted. Objects are in this state before being created and assigned an identifier.</dd>
       </dl>
       <dl>
-        <dt>Deposited</dt>
+        <dt>Submitted</dt>
         <dd>The state of object that has been saved in the repository system.</dd>
       </dl>
       <dl>
@@ -100,8 +100,8 @@
     <section>
       <h3>Actions</h3>
       <dl>
-        <dt>deposit</dt>
-        <dd>Deposits the item. Notifies curators of the new content which may be selected for preservation. Transitions the object from <code>New</code> to <code>Deposited</code>.</dd>
+        <dt>submit</dt>
+        <dd>Submits the item to the repository. Notifies curators of the new content which may be selected for preservation. Transitions the object from <code>New</code> to <code>Submitted</code>.</dd>
       </dl>
       <dl>
         <dt>preserve</dt>
@@ -109,7 +109,7 @@
       </dl>
       <dl>
         <dt>purge</dt>
-        <dd>Requests purge from all DDPs via the Gateway. Notifies curators and administrators that purge has been requested. Transitions the object from <code>Preserved</code> to <code>Deposited</code>.</dd>
+        <dd>Requests purge from all DDPs via the Gateway. Notifies curators and administrators that purge has been requested. Transitions the object from <code>Preserved</code> to <code>Submitted</code>.</dd>
       </dl>
       <dl>
         <dt>update preserved content</dt>
@@ -117,7 +117,7 @@
       </dl>
       <dl>
         <dt>comment</dt>
-        <dd>Allows curators, administrators, and automated auditors to comment on deposited or preserved objects without triggering other workflow actions. Does not transition object state.</dd>
+        <dd>Allows curators, administrators, and automated auditors to comment on submitted or preserved objects without triggering other workflow actions. Does not transition object state.</dd>
       </dl>
     </section>
     <section>
@@ -130,9 +130,9 @@
       "description": "",
       "actions": [
         {
-          "name": "deposit",
+          "name": "submit",
           "from_states": [],
-          "transition_to": "deposited",
+          "transition_to": "submitted",
           "notifications": [
             {
               "notification_type": "email",
@@ -147,7 +147,7 @@
         },
         {
           "name": "preserve",
-          "from_states": [{"names": ["deposited", "preserved"], "roles": ["curating"]}],
+          "from_states": [{"names": ["submitted", "preserved"], "roles": ["curating"]}],
           "transition_to": "preserved",
           "notifications": [
             {
@@ -163,7 +163,7 @@
         {
           "name": "purge",
           "from_states": [{"names": ["preserved"], "roles": ["curating"]}],
-          "transition_to": "deposited",
+          "transition_to": "submitted",
           "notifications": [
             {
               "notification_type": "email",
@@ -189,7 +189,7 @@
         {
           "name": "comment",
           "from_states": [
-            { "names": ["deposited"], "roles": ["curating", "admin", "auditing"] },
+            { "names": ["submitted"], "roles": ["curating", "admin", "auditing"] },
             { "names": ["preserved"], "roles": ["curating", "admin", "auditing] }
           ]
         }


### PR DESCRIPTION
These were confusing in the context, since "deposited" elsewhere means deposited
to the DDP. The new name is less likely to be conflated with other actions
described in the specs.

Connected to #81.